### PR TITLE
Allow sale of multiple LAND together

### DIFF
--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -26,8 +26,8 @@ contract Marketplace is Ownable {
     ERC721Interface public nonFungibleRegistry;
 
     struct Auction {
-        // Auction ID
-        bytes32 id;
+        // Assets for sale - array allows Auction to be used for both single and multi-asset orders
+        uint256[] assets;
         // Owner of the NFT
         address seller;
         // Price (in wei) for the published item
@@ -45,23 +45,32 @@ contract Marketplace is Ownable {
 
     /* EVENTS */
     event AuctionCreated(
-        bytes32 id,
         uint256 indexed assetId,
         address indexed seller, 
         uint256 priceInWei, 
-        uint256 expiresAt
+        uint256 expiresAt,
+        bool indexed estate
     );
     event AuctionSuccessful(
-        bytes32 id,
         uint256 indexed assetId, 
         address indexed seller, 
         uint256 totalPrice, 
-        address indexed winner
+        address indexed winner,
+        bool indexed estate
     );
     event AuctionCancelled(
-        bytes32 id,
         uint256 indexed assetId, 
-        address indexed seller
+        address indexed seller,
+        bool indexed estate
+    );
+    event EstateAuctionCreated(
+        uint256[] assets
+    );
+    event EstateAuctionSuccessful(
+        uint256[] assets 
+    );
+    event EstateAuctionCancelled(
+        uint256[] assets 
     );
 
     event ChangedPublicationFee(uint256 publicationFee);
@@ -102,26 +111,22 @@ contract Marketplace is Ownable {
     }
 
     /**
-     * @dev Cancel an already published order
+     * @dev Create a new order
      * @param assetId - ID of the published NFT
      * @param priceInWei - Price in Wei for the supported coin.
      * @param expiresAt - Duration of the auction (in hours)
      */
     function createOrder(uint256 assetId, uint256 priceInWei, uint256 expiresAt) public {
+        require(!auctionList[assetId]);
         require(nonFungibleRegistry.isAuthorized(msg.sender, assetId));
         require(nonFungibleRegistry.isAuthorized(address(this), assetId));
         require(priceInWei > 0);
         require(expiresAt > now.add(1 minutes));
-
-        bytes32 auctionId = keccak256(
-            block.timestamp, 
-            nonFungibleRegistry.ownerOf(assetId), 
-            assetId, 
-            priceInWei
-        );
-
+        
+        uint256[1] memory asset = [assetId];
+        
         auctionList[assetId] = Auction({
-            id: auctionId,
+            assets: asset,
             seller: nonFungibleRegistry.ownerOf(assetId),
             price: priceInWei,
             startedAt: now,
@@ -138,13 +143,64 @@ contract Marketplace is Ownable {
             );
         }
 
-        AuctionCreated(
-            auctionList[assetId].id, 
+        AuctionCreated( 
             assetId, 
             auctionList[assetId].seller, 
             priceInWei, 
-            expiresAt
+            expiresAt,
+            0
         );
+    }
+
+    /**
+     * @dev Create a new ESTATE order
+     * @param assets[] - Assets for sale
+     * @param priceInWei - Price in Wei for the supported coin.
+     * @param expiresAt - Duration of the auction (in hours)
+     */
+    function createEstate(uint256[] assets, uint256 priceInWei, uint256 expiresAt) public {
+        // Store locally calls needed in for loops
+        uint256 memory length = assets.length;
+        address memory myAddr = address(this);
+        
+        for (i = 0; i < length; i++) {
+            require(!auctionList[assets[i]]);
+            require(nonFungibleRegistry.isAuthorized(msg.sender, assets[i]));
+            require(nonFungibleRegistry.isAuthorized(myAddr, assets[i]));
+        }
+        require(priceInWei > 0);
+        require(expiresAt > now.add(1 minutes));
+        
+        // Check if there's a publication fee and
+        // transfer the amount to marketplace owner.
+        if (publicationFeeInWei > 0) {
+            acceptedToken.transferFrom(
+                msg.sender,
+                owner,
+                publicationFeeInWei
+            );
+        }
+
+        // Same seller for all assets - call not needed in loop
+        address memory _seller = nonFungibleRegistry.ownerOf(assets[0]);
+        Auction memory auction = Auction({
+            assets: assets,
+            seller: _seller,
+            price: priceInWei,
+            startedAt: now,
+            expiresAt: expiresAt
+        });
+        
+        for (i = 0; i < length; i++) {
+            auctionList[assets[i]] = auction; 
+            AuctionCreated( 
+                assets[i], 
+                _seller, 
+                priceInWei, 
+                expiresAt,
+                1
+            );
+            EstateAuctionCreated(assets);
     }
 
     /**
@@ -155,11 +211,28 @@ contract Marketplace is Ownable {
     function cancelOrder(uint256 assetId) public {
         require(auctionList[assetId].seller == msg.sender || msg.sender == owner);
 
-        bytes32 auctionId = auctionList[assetId].id;
         address auctionSeller = auctionList[assetId].seller;
         delete auctionList[assetId];
 
-        AuctionCancelled(auctionId, assetId, auctionSeller);
+        AuctionCancelled(assetId, auctionSeller, 0);
+    }
+
+    /**
+     * @dev Cancel an already published ESTATE order
+     *  can only be canceled by seller or the contract owner.
+     * @param assets[] - Array of the published NFT
+     */
+    function cancelEstate(uint256[] assets) public {
+        require(auctionList[assets[0]].seller == msg.sender || msg.sender == owner);
+        
+        uint256 memory length = assets.length;
+        address auctionSeller = auctionList[assets[0]].seller;
+        
+        for (i = 0; i < length; i++) {
+            delete auctionList[assets[i]];
+            AuctionCancelled(assets[i], auctionSeller, 1);
+        }
+        EstateAuctionCancelled(assets);
     }
 
     /**
@@ -167,21 +240,23 @@ contract Marketplace is Ownable {
      * @param assetId - ID of the published NFT
      */
     function executeOrder(uint256 assetId, uint256 price) public {
-        require(auctionList[assetId].seller != address(0));
-        require(auctionList[assetId].seller != msg.sender);
+        address memory _seller = auctionList[assetId].seller;
+        require(_seller != address(0));  
+        require(_seller != msg.sender);  
         require(auctionList[assetId].price == price);
         require(now < auctionList[assetId].expiresAt);
 
         address nonFungibleHolder = nonFungibleRegistry.ownerOf(assetId);
 
-        require(auctionList[assetId].seller == nonFungibleHolder);
-
+        require(_seller == nonFungibleHolder);
+        
+        uint256 memory _price = auctionList[assetId].price;
         uint saleShareAmount = 0;
 
         if (ownerCutPercentage > 0) {
 
             // Calculate sale share
-            saleShareAmount = auctionList[assetId].price.mul(ownerCutPercentage).div(100);
+            saleShareAmount = _price.mul(ownerCutPercentage).div(100);
 
             // Transfer share amount for marketplace Owner.
             acceptedToken.transferFrom(
@@ -195,22 +270,83 @@ contract Marketplace is Ownable {
         acceptedToken.transferFrom(
             msg.sender,
             nonFungibleHolder,
-            auctionList[assetId].price.sub(saleShareAmount)
+            _price.price.sub(saleShareAmount)
         );
 
         // Transfer asset owner
         nonFungibleRegistry.safeTransferFrom(
-            auctionList[assetId].seller,
+            _seller.seller,
             msg.sender,
             assetId
         );
 
-
-        bytes32 auctionId = auctionList[assetId].id;
-        address auctionSeller = auctionList[assetId].seller;
-        uint256 auctionPrice = auctionList[assetId].price;
         delete auctionList[assetId];
 
-        AuctionSuccessful(auctionId, assetId, auctionSeller, auctionPrice, msg.sender);
+        AuctionSuccessful(assetId, _seller, _price, msg.sender, 0);
+    }
+    
+    /**
+     * @dev Executes the sale for a published ESTATE NTF
+     * @param assets[] - Array of the published NFT
+     */
+    function executeEstate(uint256[] assets, uint256 price) public {
+        address memory _seller = auctionList[assets[0]].seller;
+        require(_seller != address(0));  
+        require(_seller != msg.sender); 
+        require(auctionList[assets[0]].price == price);
+        require(now < auctionList[assets[0]].expiresAt);
+
+        address nonFungibleHolder = nonFungibleRegistry.ownerOf(assets[0]);
+
+        require(auctionList[assetId].seller == nonFungibleHolder);
+
+        uint256 memory _price = auctionList[assets[0]].price;
+        uint saleShareAmount = 0;
+
+        if (ownerCutPercentage > 0) {
+
+            // Calculate sale share
+            saleShareAmount = _price.mul(ownerCutPercentage).div(100);
+
+            // Transfer share amount for marketplace Owner.
+            acceptedToken.transferFrom(
+                msg.sender,
+                owner,
+                saleShareAmount
+            );
+        }
+        
+        // Transfer sale amount to seller
+        acceptedToken.transferFrom(
+            msg.sender,
+            nonFungibleHolder,
+            _price.sub(saleShareAmount)
+        );
+
+        // Transfer asset owner
+        uint256 memory length = assets.length;
+        
+        for (i = 0; i < length; i++) {
+            nonFungibleRegistry.safeTransferFrom(
+                _seller,
+                msg.sender,
+                assets[i]
+            );
+
+            delete auctionList[assets[i]];
+            AuctionSuccessful(assets[i], _seller, _price, msg.sender, 1);
+         }
+         EstateAuctionSuccessful(assets);
     }
  }
+
+/**
+ * If you still need auctionId for a reason I am unaware of, I would
+ * add a mapping(bytes32 => Auction) auctionIds
+ *
+ * after auction item is created after 133 and after 190:
+ * bytes32 auctionId = keccak256(
+ *         block.timestamp, 
+ *         Auction object
+ * );
+ */


### PR DESCRIPTION
Here are some changes I made to allow the sale of multiple parcels together. I apologize for so many changes at once, I have never worked in a team before.

It seemed to me that the auctionId property is not used ever, even indexed for later. The hash is created at a time that is not useful to check data integrity, and the ID is only output in the events. I cannot see a purpose for this, but added a comment at the very end of how it would fit with what I have done, should it be necessary for reasons unknown to me.

I left the Auction as the only struct, as adding an Estate struct would require a separate mapping where lands and orders would be divided between the two, so this did not seem ideal. Instead I changed assetId in the struct to assets[], so that it could be used for single or multi-asset auctions. To accommodate this, in line 125 I initialized a single unit array to pass into the created auction.

In the events, took out auction Id, added bool indexed isEstate. Every event that happens on a single land sale will be categorized as such. In an estate sale, a separate event will trigger for each parcel, but the event will contain estate = true to show that it was part of an estate event. In addition, an estate event triggers that contains the complete array of assetIds involved.

Added requirement that assetId must not be mapped to Auction before an order can be created. This was okay with single asset orders, but must be prevented with multi-asset. Line 120, 167.

createEstate() is passed an array of Ids, stores a couple local items to prevent excessive calls in a for loop.I believe I worked it so that for loops create no extra gas use than for each land to be executed separately, in fact I believe it is well optimized above that as not all require statements need be checked on every loop. The logic should follow that multiple addresses cannot make a single call involving a group of assets, so checking through the assets once shows that those assets are qualified with the valid address and, in later functions, only the address of one of them needs to be checked.

In executeOrder() and executeEstate() reads to the mapping properties of seller and price were called many times throughout, so I placed a local memory item where I believe it would be most optimal for all but outlying cases. There were, however a few lines that I do not know if they are necessary. I left them just in case but I will bring them to your attention in case it can reduce gas:
- 244 and 294 - Why would these conditions be needed? Even if burned,  how would the land be posted for sale from 0x0?
- 245 and 295 - Why can the address not purchase their own land? They will simply lose money and give commission to the developers!
- combinations of 249/251 and 299/301 - When the Auction is created, it is checked that the seller recorded is the owner of the assets, therefore the same check here seems redundant and just costs extra gas.

This was related to my own desires for the market and related to issue#84 "few parcel in one publication"