### PR TITLE
Adding `percentage` suffix on ownerCut

### DIFF
--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -87,7 +87,7 @@ contract Marketplace is Migratable, Ownable, Pausable {
   );
 
   event ChangedPublicationFee(uint256 publicationFee);
-  event ChangedOwnerCut(uint256 ownerCut);
+  event ChangedOwnerCutPercentage(uint256 ownerCutPercentage);
 
   /**
     * @dev Initialize this contract. Acts as a constructor
@@ -112,14 +112,14 @@ contract Marketplace is Migratable, Ownable, Pausable {
   /**
     * @dev Sets the share cut for the owner of the contract that's
     *  charged to the seller on a successful sale
-    * @param ownerCut - Share amount, from 0 to 100
+    * @param _ownerCutPercentage - Share amount, from 0 to 100
     */
-  function setOwnerCut(uint8 ownerCut) public onlyOwner {
-    require(ownerCut < 100, "The owner cut should be between 0 to 100");
+  function setOwnerCutPercentage(uint8 _ownerCutPercentage) public onlyOwner {
+    require(_ownerCutPercentage < 100, "The owner cut should be between 0 to 100");
 
-    ownerCutPercentage = ownerCut;
+    ownerCutPercentage = _ownerCutPercentage;
 
-    emit ChangedOwnerCut(ownerCutPercentage);
+    emit ChangedOwnerCutPercentage(ownerCutPercentage);
   }
 
   /**

--- a/test/Marketplace.js
+++ b/test/Marketplace.js
@@ -454,7 +454,7 @@ contract('Marketplace', function([_, owner, seller, buyer, otherAddress]) {
     it('should change owner sale cut', async function() {
       let ownerCut = 10
 
-      await market.setOwnerCut(ownerCut, { from: owner })
+      await market.setOwnerCutPercentage(ownerCut, { from: owner })
       let r = await market.ownerCutPercentage()
       r.should.be.bignumber.equal(ownerCut)
     })
@@ -463,7 +463,7 @@ contract('Marketplace', function([_, owner, seller, buyer, otherAddress]) {
       let ownerCut = 200
 
       await market
-        .setOwnerCut(ownerCut, { from: owner })
+        .setOwnerCutPercentage(ownerCut, { from: owner })
         .should.be.rejectedWith(EVMRevert)
     })
 
@@ -471,7 +471,7 @@ contract('Marketplace', function([_, owner, seller, buyer, otherAddress]) {
       let ownerCut = 10
 
       await market
-        .setOwnerCut(ownerCut, { from: seller })
+        .setOwnerCutPercentage(ownerCut, { from: seller })
         .should.be.rejectedWith(EVMRevert)
     })
   })
@@ -504,7 +504,7 @@ contract('Marketplace', function([_, owner, seller, buyer, otherAddress]) {
 
       let ownerCut = 10
 
-      await market.setOwnerCut(ownerCut, { from: owner })
+      await market.setOwnerCutPercentage(ownerCut, { from: owner })
       await market.createOrder(erc721.address, assetId, itemPrice, endTime, {
         from: seller
       })


### PR DESCRIPTION
It basically adds `Percentage` after `ownerCut`. 

While it is only a name change, it affects the public API of the contract