### PR TITLE
feat: check if nft address implements a valid ERC721 interface

### DIFF
--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -41,7 +41,7 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
     * @param _legacyNFTAddress - Address of the NFT address used for legacy methods that don't have nftAddress as parameter
     */
   function setLegacyNFTAddress(address _legacyNFTAddress) external onlyOwner {
-    require(_legacyNFTAddress.isContract(), "The address should be a contract");
+    _requireERC721(_legacyNFTAddress);
 
     legacyNFTAddress = _legacyNFTAddress;
     emit ChangeLegacyNFTAddress(legacyNFTAddress);
@@ -65,7 +65,7 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
     require(_acceptedToken.isContract(), "The accepted token address must be a deployed contract");
     acceptedToken = ERC20Interface(_acceptedToken);
 
-    require(_legacyNFTAddress.isContract(), "The legacy NFT address should be a deployed contract");
+    _requireERC721(_legacyNFTAddress);
     legacyNFTAddress = _legacyNFTAddress;
   }
 
@@ -255,14 +255,9 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
   )
     internal
   {
-    require(nftAddress.isContract(), "The NFT Address should be a contract");
+    _requireERC721(nftAddress);
 
     ERC721Interface nftRegistry = ERC721Interface(nftAddress);
-    require(
-      nftRegistry.supportsInterface(ERC721_Interface),
-      "The NFT contract has an invalid ERC721 implementation"
-    );
-
     address assetOwner = nftRegistry.ownerOf(assetId);
 
     require(msg.sender == assetOwner, "Only the owner can create orders");
@@ -352,11 +347,9 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
   )
    internal returns (Order)
   {
+    _requireERC721(nftAddress);
+
     ERC721Verifiable nftRegistry = ERC721Verifiable(nftAddress);
-    require(
-      nftRegistry.supportsInterface(ERC721_Interface),
-      "The NFT contract has an invalid ERC721 implementation"
-    );
 
     if (nftRegistry.supportsInterface(InterfaceId_ValidateFingerprint)) {
       require(
@@ -415,5 +408,15 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
     );
 
     return order;
+  }
+
+  function _requireERC721(address nftAddress) internal view {
+    require(nftAddress.isContract(), "The NFT Address should be a contract");
+
+    ERC721Interface nftRegistry = ERC721Interface(nftAddress);
+    require(
+      nftRegistry.supportsInterface(ERC721_Interface),
+      "The NFT contract has an invalid ERC721 implementation"
+    );
   }
 }

--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -61,7 +61,6 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
   {
     Pausable.initialize(msg.sender); // Calls ownable behind the scenes...sigh
 
-    // this check will fail when calling from the construction of the erc20 token
     require(_acceptedToken.isContract(), "The accepted token address must be a deployed contract");
     acceptedToken = ERC20Interface(_acceptedToken);
 

--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -206,7 +206,7 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
       price,
       ""
     );
-    
+
     emit AuctionSuccessful(
       order.id,
       assetId,
@@ -244,6 +244,11 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
     require(nftAddress.isContract(), "The NFT Address should be a contract");
 
     ERC721Interface nftRegistry = ERC721Interface(nftAddress);
+    require(
+      nftRegistry.supportsInterface(ERC721_Interface),
+      "The NFT contract has an invalid ERC721 implementation"
+    );
+
     address assetOwner = nftRegistry.ownerOf(assetId);
 
     require(msg.sender == assetOwner, "Only the owner can create orders");
@@ -334,6 +339,10 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
    internal returns (Order)
   {
     ERC721Verifiable nftRegistry = ERC721Verifiable(nftAddress);
+    require(
+      nftRegistry.supportsInterface(ERC721_Interface),
+      "The NFT contract has an invalid ERC721 implementation"
+    );
 
     if (nftRegistry.supportsInterface(InterfaceId_ValidateFingerprint)) {
       require(

--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -99,7 +99,14 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
     * @param priceInWei - Price in Wei for the supported coin
     * @param expiresAt - Duration of the order (in hours)
     */
-  function createOrder(uint256 assetId, uint256 priceInWei, uint256 expiresAt) public whenNotPaused {
+  function createOrder(
+    uint256 assetId,
+    uint256 priceInWei,
+    uint256 expiresAt
+  )
+    public
+    whenNotPaused
+  {
     _createOrder(
       legacyNFTAddress,
       assetId,
@@ -221,7 +228,14 @@ contract Marketplace is Migratable, Ownable, Pausable, MarketplaceStorage {
     * @dev It's equivalent to orderByAssetId[legacyNFTAddress][assetId] but returns same structure as the old Auction
     * @param assetId - ID of the published NFT
     */
-  function auctionByAssetId(uint256 assetId) public view returns (bytes32, address, uint256, uint256) {
+  function auctionByAssetId(
+    uint256 assetId
+  )
+    public
+    view
+    returns
+    (bytes32, address, uint256, uint256)
+  {
     Order memory order = orderByAssetId[legacyNFTAddress][assetId];
     return (order.id, order.seller, order.price, order.expiresAt);
   }

--- a/contracts/marketplace/MarketplaceStorage.sol
+++ b/contracts/marketplace/MarketplaceStorage.sol
@@ -55,6 +55,8 @@ contract MarketplaceStorage {
     keccak256("verifyFingerprint(uint256,bytes)")
   );
 
+  bytes4 public constant ERC721_Interface = bytes4(0x80ac58cd);
+
   // EVENTS
   event OrderCreated(
     bytes32 id,

--- a/test/Marketplace.js
+++ b/test/Marketplace.js
@@ -229,9 +229,9 @@ contract('Marketplace', function([_, owner, seller, buyer, otherAddress]) {
       let _market = await Marketplace.new(erc20.address, legacyErc721.address, {
         from: owner
       })
-      let t = await _market.acceptedToken.call()
+      let acceptedToken = await _market.acceptedToken.call()
 
-      t.should.be.equal(erc20.address)
+      acceptedToken.should.be.equal(erc20.address)
     })
 
     it('should revert if token is invalid', async function() {

--- a/test/Marketplace.js
+++ b/test/Marketplace.js
@@ -556,6 +556,16 @@ contract('Marketplace', function([_, owner, seller, buyer, otherAddress]) {
       }).should.be.rejectedWith(EVMRevert)
     })
 
+    it('should fail to execute a created order :: (not an ERC721 contract)', async function() {
+      await createOrder(erc721.address, assetId, itemPrice, endTime, {
+        from: seller
+      })
+      // Not cover it at 100% but we should see it as an upgradeable contract
+      await executeOrder(erc20.address, assetId, itemPrice, {
+        from: buyer
+      }).should.be.rejectedWith(EVMRevert)
+    })
+
     it('[LEGACY] should execute a created order', async function() {
       await createOrder(legacyErc721.address, assetId, itemPrice, endTime, {
         from: seller


### PR DESCRIPTION
Close #24 

`cancelOrder` does not use the `nftAddress` that is why I only add the check at `createOrder` and `excuteOrder`